### PR TITLE
Modernize build and dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ out
 node_modules
 npm-debug.log*
 *.vsix
+dist

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,8 +1,10 @@
 .vscode/**
 typings/**
 out/test/**
+out/**
 test/**
 src/**
+node_modules/**
 **/*.map
 .gitignore
 tsconfig.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.1.0 (July 1, 2025)
+
+- Modernize dependencies and TypeScript
+- Target newer versions of VS Code
+- Replace deprecated `vscode` package with `@types/vscode`
+
 ## 1.0.4 (January 23, 2018)
 
 - Fix: paste image get blank image issue (windows)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 1.1.1 (Unreleased)
+
+- Bundle extension using esbuild
+- Exclude node modules from the packaged VSIX
+
 ## 1.1.0 (July 1, 2025)
 
 - Modernize dependencies and TypeScript

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bundle extension using esbuild
 - Exclude node modules from the packaged VSIX
+- Mark the VS Code API as external during bundling
 
 ## 1.1.0 (July 1, 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Modernize dependencies and TypeScript
 - Target newer versions of VS Code
 - Replace deprecated `vscode` package with `@types/vscode`
+- Fix compile errors when building with TypeScript 5
 
 ## 1.0.4 (January 23, 2018)
 

--- a/README.md
+++ b/README.md
@@ -235,8 +235,9 @@ If you have some any question or advice, Welcome to [issue](https://github.com/m
 
 ## Development
 
-This project now targets modern versions of VS Code and Node.js. To compile the
-extension run:
+This project now targets modern versions of VS Code and Node.js. The source in
+`src/` is bundled with [esbuild](https://esbuild.github.io/) so only a single
+JavaScript file ships with the extension. To build the bundle run:
 
 ```bash
 npm install

--- a/README.md
+++ b/README.md
@@ -237,7 +237,8 @@ If you have some any question or advice, Welcome to [issue](https://github.com/m
 
 This project now targets modern versions of VS Code and Node.js. The source in
 `src/` is bundled with [esbuild](https://esbuild.github.io/) so only a single
-JavaScript file ships with the extension. To build the bundle run:
+JavaScript file ships with the extension. The VS Code API is marked as
+external so it is resolved at runtime. To build the bundle run:
 
 ```bash
 npm install

--- a/README.md
+++ b/README.md
@@ -233,6 +233,18 @@ If you have some any question or advice, Welcome to [issue](https://github.com/m
 - [x] support config the text format
 - [x] support file path confirm box (by @DonMartin76)
 
+## Development
+
+This project now targets modern versions of VS Code and Node.js. To compile the
+extension run:
+
+```bash
+npm install
+npm run vscode:prepublish
+```
+
+Make sure you have a recent Node.js (v18 or newer) available.
+
 ## License
 
 The extension and source are licensed under the [MIT license](LICENSE.txt).

--- a/package.json
+++ b/package.json
@@ -130,9 +130,8 @@
     ]
   },
   "scripts": {
-    "vscode:prepublish": "node ./node_modules/vscode/bin/compile",
-    "compile": "node ./node_modules/vscode/bin/compile -watch -p ./",
-    "postinstall": "node ./node_modules/vscode/bin/install"
+    "vscode:prepublish": "tsc -p ./",
+    "compile": "tsc -w -p ./"
   },
   "dependencies": {
     "copy-paste": "^1.2.0",
@@ -142,7 +141,8 @@
   },
   "devDependencies": {
     "typescript": "^5.2.2",
-    "vscode": "^1.1.37",
-    "@types/node": "^20.5.9"
+    "@types/node": "^20.5.9",
+    "@types/vscode": "^1.80.0",
+    "@vscode/test-electron": "^2.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-paste-image",
   "displayName": "Paste Image",
   "description": "paste image from clipboard directly",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "publisher": "mushan",
   "author": {
     "name": "mushan",
@@ -37,7 +37,11 @@
   "activationEvents": [
     "onCommand:extension.pasteImage"
   ],
-  "main": "./out/src/extension",
+  "main": "./dist/extension.js",
+  "files": [
+    "dist",
+    "res"
+  ],
   "contributes": {
     "configuration": {
       "type": "object",
@@ -130,7 +134,9 @@
     ]
   },
   "scripts": {
-    "vscode:prepublish": "tsc -p ./",
+    "build": "tsc -p ./",
+    "bundle": "esbuild src/extension.ts --bundle --platform=node --target=node18 --outfile=dist/extension.js",
+    "vscode:prepublish": "npm run build && npm run bundle",
     "compile": "tsc -w -p ./"
   },
   "dependencies": {
@@ -143,6 +149,7 @@
     "typescript": "^5.2.2",
     "@types/node": "^20.5.9",
     "@types/vscode": "^1.80.0",
-    "@vscode/test-electron": "^2.3.0"
+    "@vscode/test-electron": "^2.3.0",
+    "esbuild": "^0.19.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-paste-image",
   "displayName": "Paste Image",
   "description": "paste image from clipboard directly",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "publisher": "mushan",
   "author": {
     "name": "mushan",
@@ -29,7 +29,7 @@
     "keybindings"
   ],
   "engines": {
-    "vscode": "^1.0.0"
+    "vscode": "^1.80.0"
   },
   "categories": [
     "Other"
@@ -136,12 +136,13 @@
   },
   "dependencies": {
     "copy-paste": "^1.2.0",
-    "fs-extra": "^3.0.1",
-    "moment": "^2.14.1",
-    "upath": "^1.0.0"
+    "fs-extra": "^11.1.1",
+    "moment": "^2.29.4",
+    "upath": "^2.0.1"
   },
   "devDependencies": {
-    "typescript": "^1.8.5",
-    "vscode": "^0.11.0"
+    "typescript": "^5.2.2",
+    "vscode": "^1.1.37",
+    "@types/node": "^20.5.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -134,9 +134,8 @@
     ]
   },
   "scripts": {
-    "build": "tsc -p ./",
-    "bundle": "esbuild src/extension.ts --bundle --platform=node --target=node18 --outfile=dist/extension.js",
-    "vscode:prepublish": "npm run build && npm run bundle",
+    "bundle": "esbuild src/extension.ts --bundle --platform=node --target=node18 --external:vscode --outfile=dist/extension.js",
+    "vscode:prepublish": "npm run bundle",
     "compile": "tsc -w -p ./"
   },
   "dependencies": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -90,7 +90,11 @@ class Paster {
         }
         let filePath = fileUri.fsPath;
         let folderPath = path.dirname(filePath);
-        let projectPath = vscode.workspace.rootPath;
+        let projectPath = '';
+        const workspaceFolders = vscode.workspace.workspaceFolders;
+        if (workspaceFolders && workspaceFolders.length > 0) {
+            projectPath = workspaceFolders[0].uri.fsPath;
+        }
 
         // get selection as image file name, need check
         var selection = editor.selection;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as fse from 'fs-extra';
 import { spawn } from 'child_process';
-import * as moment from 'moment';
+import moment from 'moment';
 import * as upath from 'upath';
 
 class Logger {
@@ -38,7 +38,7 @@ export function activate(context: vscode.ExtensionContext) {
         try {
             Paster.paste();
         } catch (e) {
-            Logger.showErrorMessage(e)
+            Logger.showErrorMessage(String(e))
         }
     });
 
@@ -313,11 +313,11 @@ class Paster {
                 '-file', scriptPath,
                 imagePath
             ]);
-            powershell.on('error', function (e) {
+            powershell.on('error', function (e: NodeJS.ErrnoException) {
                 if (e.code == "ENOENT") {
                     Logger.showErrorMessage(`The powershell command is not in you PATH environment variables. Please add it and retry.`);
                 } else {
-                    Logger.showErrorMessage(e);
+                    Logger.showErrorMessage(e.message ?? String(e));
                 }
             });
             powershell.on('exit', function (code, signal) {
@@ -332,8 +332,8 @@ class Paster {
             let scriptPath = path.join(__dirname, '../../res/mac.applescript');
 
             let ascript = spawn('osascript', [scriptPath, imagePath]);
-            ascript.on('error', function (e) {
-                Logger.showErrorMessage(e);
+            ascript.on('error', function (e: Error) {
+                Logger.showErrorMessage(e.message);
             });
             ascript.on('exit', function (code, signal) {
                 // console.log('exit',code,signal);
@@ -347,8 +347,8 @@ class Paster {
             let scriptPath = path.join(__dirname, '../../res/linux.sh');
 
             let ascript = spawn('sh', [scriptPath, imagePath]);
-            ascript.on('error', function (e) {
-                Logger.showErrorMessage(e);
+            ascript.on('error', function (e: Error) {
+                Logger.showErrorMessage(e.message);
             });
             ascript.on('exit', function (code, signal) {
                 // console.log('exit',code,signal);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,16 @@
 {
-    "compilerOptions": {
-        "module": "commonjs",
-        "target": "es5",
-        "outDir": "out",
-        "noLib": true,
-        "sourceMap": true,
-        "rootDir": "."
-    },
-    "exclude": [
-        "node_modules",
-        ".vscode-test"
-    ]
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2019",
+    "lib": ["es2019"],
+    "outDir": "out",
+    "rootDir": ".",
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "moduleResolution": "node",
+    "types": ["node", "vscode"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", ".vscode-test"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "es2019",
     "lib": ["es2019"],
     "outDir": "out",
-    "rootDir": ".",
+    "rootDir": "src",
     "sourceMap": true,
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,8 +8,7 @@
     "sourceMap": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "moduleResolution": "node",
-    "types": ["node", "vscode"]
+    "moduleResolution": "node"
   },
   "include": ["src"],
   "exclude": ["node_modules", ".vscode-test"]


### PR DESCRIPTION
## Summary
- update VS Code engine and dependency versions
- add Node typings and modern TypeScript
- refresh tsconfig for modern builds
- modernize workspace root access
- document build instructions
- fix `vscode` devDependency version

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_686344366458832cbc35c296e290d7c0